### PR TITLE
first iteration of carousel size handling + others

### DIFF
--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -7,47 +7,65 @@ type PorfolioEntry = CollectionEntry<'portfolio'>;
 type FeaturedEntry = PorfolioEntry | WritingEntry
 
 const {carouselData} = Astro.props;
+
 // max length depending 
-const CarouselMaxLength = (((carouselData.length > 1 ? carouselData.length : 2) - 1) * 20).toString() + "rem"; 
+// const CarouselMaxLength = ((( testCarouselData3.length > 1 ?  testCarouselData3.length : 2) - 1) * 20).toString() + "rem";
+const CarouselMaxLength = (carouselData.length * 21).toString() + "rem";
+
+const testCarouselData = [...carouselData];
+// if 
+const buttonHiddenClass = (testCarouselData.length === 1) ? "hidden" : "";
+const centerSingleFeaturedArticleClass = (testCarouselData.length === 1) ? "justify-center content-center" : "";
 ---
 
-<div class="w-full" style={{maxWidth: CarouselMaxLength}}>
+<!-- Why inline style? Tailwind's JIT compiler can only extract statically analyzable classnames during build time -->
+<div class={`w-full `} style={`max-width: ${CarouselMaxLength};`}>
+    {/* the carousel is hidden until the javascript is executed. the placeholder is used to prevent layout shifts */}
+    {/* embla__viewport is the viewport of the carousel, embla__container is the container of the carousel items */}
+    {/* embla__button--prev and embla__button--next are the buttons for previous and next respectively */}
     {/* grid is for overlapping buttons (isLoading? "hidden":)*/}
     <div class={"w-full grid grid-cols-[1fr_1fr] embla hidden"}>
-        <!-- embla part h-42-->
-        <div class="overflow-hidden w-full col-[1_/_3] row-[1_/_2] embla__viewport">
-            <!-- viewport -->
-            <div class="flex mt-5 col-[1_/_4] [&>*]:m-2 embla__container" >
-            <!-- {console.log(Array.isArray(carouselData), "bruh3")} -->
-            {/* using center for the alignment is very weird as it reformatted on screen. align: start is used instead*/
-                carouselData.map((carouselDatum : FeaturedEntry ) =>
-                    <FeaturedArticleCard featuredArticleData={carouselDatum}/>
-                )
+        <!-- embla part h-42 overflow-hidden-->
+        <div class=" w-full col-[1_/_3] row-[1_/_2] overflow-hidden embla__viewport">
+            <!-- viewport carousel-sm:justify-center -->
+            <div class={`flex mt-5 col-[1_/_4] [&>*]:m-2 embla__container ${centerSingleFeaturedArticleClass}`}>
+            <!--  -->
+            {/*using center for the alignment is very weird as it reformatted on screen. align: start is used instead*/
+                (testCarouselData.length > 1) ? (
+                    [...testCarouselData, ...testCarouselData].map((carouselDatum : FeaturedEntry ) =>
+                        <FeaturedArticleCard featuredArticleData={carouselDatum}/>
+                    )
+            ) : (
+                <article class=" flex justify-center content-center">
+                    {/* Thumbnail. h & w need to be full as img is a container for the img. This makes object-cover work grid-cols-[minmax(_18rem,18rem)*/}
+                    {/* title description thingy. Max  _20rem*/}
+                    <FeaturedArticleCard featuredArticleData={testCarouselData[0]}/>
+                </article>
+            )
             }
             </div>
         </div>
         {/* using absolute position is a bit wonky as it will change z-index and thus interactivity
         of the carousel. positioning using flex and margin is required. for SVG, consider changing svg
-        d attribute so that center is not necessary*/}
-        <div class="flex justify-start col-[1_/_2] row-[1_/_2] mb-5">
-            <button class="flex justify-center items-center self-center w-12 h-12 bg-black z-10 ml-5 rounded-full embla__button--prev">
-            <svg width="25px" height="25px" viewBox="0 0 24 24">
-                <path xmlns="http://www.w3.org/2000/svg" d="M10.122 24l-4.122-4 8-8-8-8 4.122-4 11.878 12z" 
-                stroke="white" fill="white" style={{transform:"scale(-1, 1) translate(-100%, 0px)"}}/>
-                {/* transform="scale(-1 1) translate(-800px 0px)" style={{transform:"scale(-1, 1) translate(-40px, 0px)"}}*/}
-            </svg>
+        d attribute so that center is not necessary */}
+        <div class={`flex justify-start col-[1_/_2] row-[1_/_2] mb-5 ${buttonHiddenClass}`}>
+            <button class="flex justify-center items-center self-center w-12 h-12 bg-black z-10 ml-5 round embla__button--prev">
+                <svg width="25px" height="25px" viewBox="0 0 24 24">
+                    <path xmlns="http://www.w3.org/2000/svg" d="M10.122 24l-4.122-4 8-8-8-8 4.122-4 11.878 12z" 
+                    stroke="white" fill="white" style={{transform:"scale(-1, 1) translate(-100%, 0px)"}}/>
+                </svg>
             </button>
         </div>
-        <div class="flex justify-end col-[2_/_3] row-[1_/_2] mb-5">
-            <button class="flex justify-center items-center self-center w-12 h-12 bg-black z-10 mr-5 rounded-full embla__button--next">
-            <svg width="25px" height="25px" viewBox="0 0 24 24">
-                <path xmlns="http://www.w3.org/2000/svg" d="M10.122 24l-4.122-4 8-8-8-8 4.122-4 11.878 12z" stroke="white" fill="white"/>
-            </svg>
+        <div class={`flex justify-end col-[2_/_3] row-[1_/_2] mb-5 ${buttonHiddenClass}`}>
+            <button class="flex justify-center items-center self-center w-12 h-12 bg-black z-10 mr-5 round embla__button--next">
+                <svg width="25px" height="25px" viewBox="0 0 24 24">
+                    <path xmlns="http://www.w3.org/2000/svg" d="M10.122 24l-4.122-4 8-8-8-8 4.122-4 11.878 12z" stroke="white" fill="white"/>
+                </svg>
             </button>
         </div>
     </div>
     <div class={"flex content-align justify-center placeholder"}>
-        <!-- height is must be exactly 38.25 to prevent layout shifts once the carousel is revealed -->
+        <!-- height must be exactly 38.25 to prevent layout shifts once the carousel is revealed -->
         <svg width="250" height="38.25rem" >
             <rect x="5" y="296" width="40" height="80" rx="5" ry="5">
             </rect>
@@ -65,13 +83,14 @@ const CarouselMaxLength = (((carouselData.length > 1 ? carouselData.length : 2) 
     </div>
 </div>
 
+
 <script >
     // NOTE: Below implements the carousel I don't quite understand the javascript code below.
     // the carousel is hidden and a placeholder is in its place until all the carousel
     // setup is executed. the placeholder is hidden first then the carousel is revealed
     import EmblaCarousel, { type EmblaOptionsType, type EmblaCarouselType } from 'embla-carousel';
-    // loop: true
-    const OPTIONS: EmblaOptionsType = { dragFree: true, loop: true};
+    // ,
+    const OPTIONS: EmblaOptionsType = {dragFree: true, loop: true};
     const viewportNode = document.querySelector('.embla__viewport') as HTMLElement;
     const emblaApi = EmblaCarousel(viewportNode, OPTIONS);
 
@@ -146,8 +165,16 @@ const CarouselMaxLength = (((carouselData.length > 1 ? carouselData.length : 2) 
     // now that everything is properly formatted, we remove the suspence and reveal the embla node.
     
 
+    function logResize(emblaApi: EmblaCarouselType): void {
+        console.log("embla resized");
+
+        // console.log(emblaApi.reInit());
+        // console.log(emblaApi.scrollSnapList());
+    }
 
 
-    // we need make it so that the  
+
+    // we need make it so that the carousel updates its layout on resize
+    emblaApi.on("resize", () => logResize(emblaApi));
 
 </script>

--- a/src/components/FeaturedArticleCard.astro
+++ b/src/components/FeaturedArticleCard.astro
@@ -15,11 +15,10 @@ if (!images[featuredArticleData.data.heroImage]) throw new Error(`"${featuredArt
     {/* title description thingy. Max  _20rem*/}
     <div class="card grid grid-rows-[minmax(_0rem,_20rem)_minmax(_0rem,_16rem)] grid-cols-[minmax(_20rem,_20rem)] bg-white rounded-md 
     font-notoSerif ">
-        <!-- loading="lazy"
-        decoding="async" -->
         <Image class="object-cover h-full w-full rounded-t-md" 
         alt={featuredArticleData.data.alt} 
-        src={images[featuredArticleData.data.heroImage]()}></Image>
+        src={images[featuredArticleData.data.heroImage]()}
+        loading="eager"></Image>
         <div class="flex flex-col p-4 justify-between">
             <div class="flex flex-col grow gap-3 overflow-hidden">
                 {/* advanced-truncation is for truncating and putting ellipses on overflowing text content. ELLIPSES HANDLED ON global.css

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -25,16 +25,15 @@ const conditionalNavClasses = isLandingPage ? " " : " grid grid-cols-2 sm:grid-c
 const conditionalHeaderClasses = isLandingPage ? " absolute right-0 " : " ";
 
 ---
-
+<!-- bg-${BGColor} opacity-55 -->
 <!-- conditionalHeaderClasses is for absolute positioning which conveniently prevents scroll bar on Landing page: duration-300 -->
 <header class={`h-8 font-notoSerif fixed z-50 w-full top-0 text-${color} bg-${BGColor} ${conditionalHeaderClasses}`}>
-	<!-- is there a way to do this without inline styling? -->
-	<nav class={`h-full w-full ${conditionalNavClasses}`}>
-		<!-- removing bg-color for as header handles it + "bg-" + BGColor -->
+	<nav class={`h-full w-full ${conditionalNavClasses}`}
+	style="backdrop-filter: blur(10px);">
 		{!isLandingPage && 
 			<div class={``}>
-				{/* the div is used to provide the background for the logo */}
-				<div class={`absolute bg-PWWhite p-1 round`}>
+
+				<div class={`absolute bg-${BGColor} p-1.5 round`}>
 					<img class={`logo round h-10`} alt="logo" src={logo.src} loading="eager" decoding="sync">
 
 				</div>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -13,7 +13,6 @@ type Props = CollectionEntry<'portfolio'>['data'];
 const { title, description, pubDate, updatedDate, heroImage, alt, tags, isFeatured} = Astro.props;
 const images = import.meta.glob<{ default: ImageMetadata }>('/src/assets/article-placeholders/*.{jpeg,jpg,png,gif,webp}')
 
-// console.log(tags);
 
 if (!images[`${heroImage}`]) throw new Error(`"${heroImage}" does not exist in glob: "/src/assets/article-placeholders/*.{jpeg,jpg,png,gif,webp}"`);
 ---
@@ -27,18 +26,16 @@ if (!images[`${heroImage}`]) throw new Error(`"${heroImage}" does not exist in g
         <link href="https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=fallback" rel="stylesheet">
 	</head>
 
-	<body class="w-full">
+	<body class="w-full ">
 		<Header isLandingPage = {false} color="PWBlack" BGColor="PWWhite"/>
-		<!-- <img width={1020} height={510} src={`${heroImage}`} alt={`${alt}`}> -->
-
 		<main class="flex flex-col items-center justify-center relative bg-PWWhite w-full">
-			<!-- might have to make an wrapper But don't have a great reason fro it at this point? -->
-			<!-- <section class="hero-image w-full h-[calc(90vh-80px)] overflow-hidden">  bottom-0  -->
+			<!-- might have to make wrapper But don't have a great reason for it at this point? -->
 			<section class="relative w-full h-[calc(70vh-80px)] overflow-hidden z-20 border-t-[2px]">
 				{heroImage && <Image class="w-full fixed top-0 object-center object-cover h-[calc(70vh-80px)] z-10"  
-				src={images[heroImage]()} alt={`${alt}`} />}
+				src={images[heroImage]()} alt={`${alt}`} loading="eager"/>}
 			</section>
-			<div class="relative w-full flex items-center justify-center bg-PWWhite z-30 border-t-[2px] border-solid border-PWBlack">
+			<!-- maybe add a border to the top "border-t-2 border-black border-solid" -->
+			<div class="relative w-full flex items-center justify-center bg-PWWhite z-30 ">
 				<!--the grid col size is only relevant at specific breakpoint-->
 				<article class="relative bg-PWWhite max-w-7xl gap-5 pt-5 grid z-50
 				grid-cols-[0rem_1fr_0rem] px-[1rem]
@@ -105,15 +102,15 @@ if (!images[`${heroImage}`]) throw new Error(`"${heroImage}" does not exist in g
 
 					<!-- content take width of screen at smallest size -->
 					<section class="font-notoSerif text-lg
-					col-[1_/_-1] row-[7_/_8]
-					txt-body-sm:col-[1_/_3] txt-body-sm:row-[7_/_8]
-					txt-body-md:col-[2_/_3] txt-body-md:row-[7_/_8]">
+					col-[1_/_-1] row-[6_/_7]
+					txt-body-sm:col-[1_/_3] txt-body-sm:row-[6_/_7]
+					txt-body-md:col-[2_/_3] txt-body-md:row-[5_/_6]">
 						<slot  />
 					</section>
 
 
 					<div class="flex flex-col items-center justify-center
-					col-[1_/_-1] row-[8_/_9]">
+					col-[1_/_-1] row-[7_/_8]">
 						<Footer/>
 					</div>
 				</article>

--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -8,9 +8,12 @@ import ArticleCard from "../../components/ArticleCard.astro";
 
 
 type PortfolioEntry = CollectionEntry<"portfolio">;
-const portfolio  : PortfolioEntry[] = await getCollection("portfolio");
+const portfolio  : PortfolioEntry[] = (await getCollection("portfolio")).sort((a, b) => {
+    return new Date(b.data.pubDate).getTime() - new Date(a.data.pubDate).getTime();
+});
 
 const featuredPortfolio : PortfolioEntry[] = portfolio.filter((portfolioEntry) => portfolioEntry.data.isFeatured == true);
+
 
 // console.log(featuredPortfolio);
 ---
@@ -66,15 +69,21 @@ const featuredPortfolio : PortfolioEntry[] = portfolio.filter((portfolioEntry) =
 
 
             <!-- portfolio area -->
-            <section class="mt-10 gap-5 mx-4 grid portfolio-area
-                            grid-cols-[repeat(_1,_minmax(_18rem,_30rem))]
-                            lg:grid-cols-[repeat(_4,_minmax(_18rem,_30rem))]
-                            md:grid-cols-[repeat(_3,_minmax(_18rem,_30rem))]
-                            sm:grid-cols-[repeat(_2,_minmax(_18rem,_30rem))]">
-                {portfolio.map((portfolioDatum) => 
-                    <ArticleCard articleDatum={portfolioDatum}/>
-                )}
-            </section>
+            {portfolio ? (
+                <section class="mt-10 gap-5 mx-4 grid portfolio-area
+                                grid-cols-[repeat(_1,_minmax(_18rem,_30rem))]
+                                lg:grid-cols-[repeat(_4,_minmax(_18rem,_30rem))]
+                                md:grid-cols-[repeat(_3,_minmax(_18rem,_30rem))]
+                                sm:grid-cols-[repeat(_2,_minmax(_18rem,_30rem))]">
+                    {portfolio.map((portfolioDatum) => 
+                        <ArticleCard articleDatum={portfolioDatum}/>
+                    )}
+                </section>
+            ) : (
+                <p class="font-notoSerif text-xl font-medium mt-10 text-PWBlack text-center	">
+                    Nothing here yet? Might be an error or I haven't added anything yet.
+                </p>
+            )}
 
         </main>
     </body>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -5,6 +5,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getCollection } from 'astro:content';
 import Carousel from '../../components/Carousel.astro';
 import { type CollectionEntry } from 'astro:content';
+// import { undefined } from 'astro:schema';
 
 // import {type col}
 // import FormattedDate from '../../components/FormattedDate.astro';
@@ -63,6 +64,8 @@ const dateRegex = /\d\d\d\d-\d\d-\d\d/g;
             </input>
 
             <!-- article area  h-full -->
+            <!-- portfolio area -->
+            {writing ? (
             <section class="flex flex-col gap-3 w-fit max-w-[40rem] h-full mx-5 mt-10">
                 <!-- {console.log(Array.isArray(writing), "bruh2")} -->
                 {writing.map(((articleDatum : WritingEntry) =>
@@ -83,12 +86,16 @@ const dateRegex = /\d\d\d\d-\d\d-\d\d/g;
                                 <h6 class="font-notoSerif advanced-truncation-1 title-text text-base font-bold min-w-[10rem]">
                                     {articleDatum.data.title}
                                 </h6>
-                                <p class="font-notoSerif advanced-truncation-1 text-base"> {articleDatum.data.description}</p>
                             </div>
                         </article>
                     </a>
                 ))}
             </section>
+            ) : (
+            <p class="font-notoSerif text-xl font-medium mt-10 text-PWBlack text-center	">
+                Nothing here yet? Might be an error or I haven't added anything yet.
+            </p>
+            )}
         </main>
     </body>
 </html>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -6,6 +6,7 @@ export default {
 			colors: {
 				PWBlack: '#141414',
 				PWWhite: "#fff7f4",
+				PWWhiteTranslucent: "#fff7f490",
 				PWOlive: "#BCCABC",
 				PWRed: {
 					500: "#CE4B6D",
@@ -61,6 +62,10 @@ export default {
 				"txt-body-md": "960px",
 				"txt-body-lg": "1240px",
 				"txt-body-xl": "1500px",
+				"carousel-sm": "1010px",
+				"carousel-md": "960px",
+				"carousel-lg": "1240px",
+				"carousel-xl": "1500px",
 			},
 		},
 	},


### PR DESCRIPTION
- first iteration of carousel size handling 
	- Done by restricting max width size to accommodate the number of actual articles.
	- Then we clone all the articles to provide clean loop of all content.
- added empty states for the carousel and the writing section and the project section.
- turned the button divs for the carousel into CSS clip path rather than border hacks

very simple and solves the problem perfectly, but may impact website perf a bit. Alright for now.

Ideal iteration clones at most two items on both sides of looping carousel, but will have to do some hacky stuff with the Embla API and possibly the engine. So, I will put it off for now.